### PR TITLE
added in the ability to detect bad config files 

### DIFF
--- a/lib/jlint.rb
+++ b/lib/jlint.rb
@@ -34,7 +34,12 @@ class Jlint
   private
 
   def parse_lint command, config_path, file_path
-    parse `java -jar #{checkstyle_command} -c #{config_path} #{file_path}`
+    output = `java -jar #{checkstyle_command} -c #{config_path} #{file_path}`
+    if /Unable to create Checker|Error loading configuration file/ =~ output
+      raise output
+    else
+      parse output
+    end
   end
 
   def as_file content, format = ".java"

--- a/lib/jlint/version.rb
+++ b/lib/jlint/version.rb
@@ -1,3 +1,3 @@
 class Jlint
-  VERSION = '0.1.2'
+  VERSION = '0.1.3'
 end

--- a/test/jlint/test_jlint.rb
+++ b/test/jlint/test_jlint.rb
@@ -20,11 +20,34 @@ describe Jlint do
 }]
     result = Jlint.lint(content)
     assert result.is_a?(Array)
-    assert !result.include?(["File does not end with a newline.", 0])
     assert_equal(result.to_yaml, File.read('test/support/custom_config_errors.yml'))
   end
 
   it "should lint with custom config content" do
+    content = %Q[import java.util.*;
+public class Sample {
+  public static void Sample() {
+  }
+
+  public void hi(long name) {
+    system.out.printf("Hi, " + name);
+  }
+}]
+    config_content = %Q[<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="AvoidStarImport"/>
+  </module>
+</module>]
+    result = Jlint.new(config_content).lint(content)
+    assert result.is_a?(Array)
+    assert result.include?(["Using the '.*' form of import should be avoided - java.util.*.", 1])
+  end
+
+  it "should error on bad custom config content" do
     content = %Q[public class Sample {
   public static void Sample() {
   }
@@ -38,10 +61,28 @@ describe Jlint do
           "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
           "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 <module name="Checker">
+  <module name="AvoidStarImport"/>
 </module>]
-    result = Jlint.new(config_content).lint(content)
-    assert result.is_a?(Array)
-    assert !result.include?(["Missing package-info.java file.", 0])
+    assert_raises(RuntimeError) { Jlint.new(config_content).lint(content) }
+  end
+
+  it "should error on bad XML" do
+    content = %Q[public class Sample {
+  public static void Sample() {
+  }
+
+  public void hi(long name) {
+    system.out.printf("Hi, " + name);
+  }
+}]
+    config_content = %Q[<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+<module name="Checker">
+  <module name="AvoidStarImport"/>
+</module]
+    assert_raises(RuntimeError) { Jlint.new(config_content).lint(content) }
   end
 
 end

--- a/test/support/custom_config_errors.yml
+++ b/test/support/custom_config_errors.yml
@@ -1,6 +1,4 @@
 ---
-- - Missing package-info.java file.
-  - 0
 - - Missing a Javadoc comment.
   - 1
 - - Missing a Javadoc comment.

--- a/test/support/sample_errors.yml
+++ b/test/support/sample_errors.yml
@@ -1,6 +1,4 @@
 ---
-- - Missing package-info.java file.
-  - 0
 - - Missing a Javadoc comment.
   - 1
 - - Missing a Javadoc comment.


### PR DESCRIPTION
I wanted to be able to error on a bad config in the event that one is passed in as an argument on gitlab-doge. Added the ability and updated the specs to test both cases of bad configs.
